### PR TITLE
(#1) Add timing repair stage efter synth

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -409,6 +409,14 @@ $(WRAPPED_LIBS):
 .PHONY: synth
 synth: $(RESULTS_DIR)/1_synth.v
 
+.PHONY: synth-repair
+synth-repair: synth
+	$(UNSET_AND_MAKE) do-synth-repair
+
+.PHONY: do-synth-repair
+do-synth-repair:
+	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/synth_repair.tcl) 2>&1 | tee $(abspath $(LOG_DIR)/1_synth_repair.log)
+
 .PHONY: synth-report
 synth-report: synth
 	$(UNSET_AND_MAKE) do-synth-report
@@ -416,6 +424,15 @@ synth-report: synth
 .PHONY: do-synth-report
 do-synth-report:
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/synth_metrics.tcl) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys_metrics.log)
+
+.PHONY: synth-repair-report
+synth-repair-report: synth-repair
+	$(UNSET_AND_MAKE) do-synth-repair-report
+
+.PHONY: do-synth-repair-report
+do-synth-repair-report:
+	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/synth_repair_metrics.tcl) 2>&1 | tee $(abspath $(LOG_DIR)/1_2_synth_repair_metrics.log)
+
 
 .PHONY: memory
 memory:

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -488,6 +488,7 @@ $(RESULTS_DIR)/1_synth.v: $(RESULTS_DIR)/1_1_yosys.v
 clean_synth:
 	rm -f $(RESULTS_DIR)/1_* $(RESULTS_DIR)/mem*.json
 	rm -f $(REPORTS_DIR)/synth_*
+	rm -f $(REPORTS_DIR)/1_*
 	rm -f $(LOG_DIR)/1_*
 	rm -f $(SYNTH_STATS)
 	rm -f $(SDC_FILE_CLOCK_PERIOD)

--- a/flow/scripts/synth_metrics.tcl
+++ b/flow/scripts/synth_metrics.tcl
@@ -1,5 +1,4 @@
 utl::set_metrics_stage "synth__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 1_1_yosys.v 1_synth.sdc
-
 report_metrics 1 "Post synthesis" false false

--- a/flow/scripts/synth_metrics.tcl
+++ b/flow/scripts/synth_metrics.tcl
@@ -1,4 +1,5 @@
 utl::set_metrics_stage "synth__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 1_1_yosys.v 1_synth.sdc
+
 report_metrics 1 "Post synthesis" false false

--- a/flow/scripts/synth_repair.tcl
+++ b/flow/scripts/synth_repair.tcl
@@ -1,0 +1,7 @@
+source $::env(SCRIPTS_DIR)/load.tcl
+source $::env(SCRIPTS_DIR)/util.tcl
+load_design 1_synth.v 1_synth.sdc
+repair_timing_helper 0
+write_verilog $::env(RESULTS_DIR)/1_2_synth-repair.v
+write_db $::env(RESULTS_DIR)/1_2_synth-repair.odb
+write_sdc -no_timestamp $::env(RESULTS_DIR)/1_2_synth-repair.sdc

--- a/flow/scripts/synth_repair_metrics.tcl
+++ b/flow/scripts/synth_repair_metrics.tcl
@@ -1,0 +1,4 @@
+utl::set_metrics_stage "synth__{}"
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 1_2_synth-repair.v 1_2_synth-repair.sdc
+report_metrics 1_2 "Post synthesis repair" false false


### PR DESCRIPTION
Add one additional step `synth-repair` that runs `repair_timing` on the result from the `synth` stage.

Also add `synth-repair-report` to report the timing after the repair.

Note that the `floorplan` stage still uses the results from the `synth` stage as starting point.